### PR TITLE
feat: define ledger schema

### DIFF
--- a/internal/resources/ledger_schema.go
+++ b/internal/resources/ledger_schema.go
@@ -1,0 +1,211 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/terraform-provider-stack/internal"
+	"github.com/formancehq/terraform-provider-stack/internal/server/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/dynamicplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                     = &Ledger{}
+	_ resource.ResourceWithConfigure        = &Ledger{}
+	_ resource.ResourceWithConfigValidators = &Ledger{}
+	_ resource.ResourceWithValidateConfig   = &Ledger{}
+)
+
+type LedgerSchema struct {
+	store *internal.ModuleStore
+}
+
+type LedgerSchemaModel struct {
+	Version types.String  `tfsdk:"version"`
+	Ledger  types.String  `tfsdk:"ledger"`
+	Schema  types.Dynamic `tfsdk:"schema"`
+}
+
+func NewLedgerSchema() func() resource.Resource {
+	return func() resource.Resource {
+		return &LedgerSchema{}
+	}
+}
+
+var SchemaLedgerSchema = schema.Schema{
+	Description: "Resource for managing a Formance Ledger Schema. For advanced usage and configuration, see the [Ledger documentation](https://docs.formance.com/ledger/).",
+	Attributes: map[string]schema.Attribute{
+		"version": schema.StringAttribute{
+			Required:    true,
+			Description: "The version of the schema.",
+		},
+		"ledger": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of the ledger.",
+		},
+		"schema": schema.DynamicAttribute{
+			Required:    true,
+			Description: "The schema definition in JSON format.",
+			PlanModifiers: []planmodifier.Dynamic{
+				dynamicplanmodifier.RequiresReplace(),
+			},
+		},
+	},
+}
+
+// Schema implements resource.Resource.
+func (s *LedgerSchema) Schema(ctx context.Context, req resource.SchemaRequest, res *resource.SchemaResponse) {
+	res.Schema = SchemaLedgerSchema
+}
+
+// Configure implements resource.ResourceWithConfigure.
+func (s *LedgerSchema) Configure(ctx context.Context, req resource.ConfigureRequest, res *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	store, ok := req.ProviderData.(internal.Store)
+	if !ok {
+		res.Diagnostics.AddError(
+			"Invalid Provider Data",
+			fmt.Sprintf("Expected *formance.Formance, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	s.store = store.NewModuleStore("ledger")
+}
+
+func (s *LedgerSchemaModel) parseSchema() (map[string]shared.V2ChartSegment, error) {
+	_, ok := s.Schema.UnderlyingValue().(types.Object)
+	if !ok {
+		return nil, fmt.Errorf("schema is not a valid JSON object")
+	}
+	v2Schema := map[string]shared.V2ChartSegment{}
+	if err := json.Unmarshal([]byte(s.Schema.String()), &v2Schema); err != nil {
+		return nil, fmt.Errorf("failed to marshal schema: %w", err)
+	}
+
+	return v2Schema, nil
+}
+
+func (s *LedgerSchema) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, res *resource.ValidateConfigResponse) {
+	var conf LedgerSchemaModel
+	res.Diagnostics.Append(req.Config.Get(ctx, &conf)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	if _, ok := conf.Schema.UnderlyingValue().(types.Object); !ok {
+		res.Diagnostics.AddError("Invalid Ledger Query", "The ledger_query must be a valid JSON object.")
+	} else {
+		logging.FromContext(ctx).Debug("Ledger query is valid")
+		_, err := conf.parseSchema()
+		if err != nil {
+			res.Diagnostics.AddError("Invalid Configuration", fmt.Sprintf("Failed to create configuration for reconciliation policy: %s", err))
+		}
+	}
+
+}
+
+// Create implements resource.Resource.
+func (s *LedgerSchema) Create(ctx context.Context, req resource.CreateRequest, res *resource.CreateResponse) {
+	var plan LedgerSchemaModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	schemaData, err := plan.parseSchema()
+	if err != nil {
+		res.Diagnostics.AddError("Invalid Schema", fmt.Sprintf("Failed to parse schema: %s", err))
+		return
+	}
+	config := operations.V2InsertSchemaRequest{
+		Ledger:  plan.Ledger.ValueString(),
+		Version: plan.Version.ValueString(),
+		V2SchemaData: shared.V2SchemaDataInput{
+			Chart: schemaData,
+		},
+	}
+
+	ledgerSdk := s.store.Ledger()
+	s.store.CheckModuleHealth(ctx, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	_, err = ledgerSdk.InsertSchema(ctx, config)
+	if err != nil {
+		sdk.HandleStackError(ctx, err, &res.Diagnostics)
+		return
+	}
+
+	res.Diagnostics.Append(res.State.Set(ctx, &plan)...)
+}
+
+// Delete implements resource.Resource.
+func (s *LedgerSchema) Delete(ctx context.Context, req resource.DeleteRequest, res *resource.DeleteResponse) {
+	res.Diagnostics.AddWarning("Delete not implemented", "The Delete method for LedgerSchema is not implemented.")
+
+}
+
+// Metadata implements resource.Resource.
+func (s *LedgerSchema) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ledger_schema"
+}
+
+// Read implements resource.Resource.
+func (s *LedgerSchema) Read(ctx context.Context, req resource.ReadRequest, res *resource.ReadResponse) {
+	var state LedgerSchemaModel
+	res.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	ledgerSdk := s.store.Ledger()
+	s.store.CheckModuleHealth(ctx, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+	readSchemaResponse, err := ledgerSdk.GetSchema(ctx, operations.V2GetSchemaRequest{
+		Ledger:  state.Ledger.ValueString(),
+		Version: state.Version.ValueString(),
+	})
+	if err != nil {
+		sdk.HandleStackError(ctx, err, &res.Diagnostics)
+		return
+	}
+
+	schema := readSchemaResponse.V2SchemaResponse.Data.Data.Chart
+	if len(schema) >= 0 {
+		data, err := json.Marshal(schema)
+		if err != nil {
+			res.Diagnostics.AddError("Schema Marshalling Error", fmt.Sprintf("Failed to marshal schema: %s", err))
+			return
+		}
+		var m = make(map[string]any)
+		if err := json.Unmarshal(data, &m); err != nil {
+			res.Diagnostics.AddError("Schema Unmarshalling Error", fmt.Sprintf("Failed to unmarshal schema: %s", err))
+			return
+		}
+		tfValues := ConvertToAttrValues(m)
+		state.Schema = types.DynamicValue(NewDynamicObjectValue(tfValues).Value())
+	}
+	state.Version = types.StringValue(readSchemaResponse.V2SchemaResponse.Data.Version)
+	state.Ledger = types.StringValue(state.Ledger.ValueString())
+	res.Diagnostics.Append(res.State.Set(ctx, &state)...)
+}
+
+// Update implements resource.Resource.
+func (s *LedgerSchema) Update(ctx context.Context, req resource.UpdateRequest, res *resource.UpdateResponse) {
+	res.Diagnostics.AddWarning("Update not implemented", "The Update method for LedgerSchema is not implemented. Recreating the resource. Make sure to inscrease the version")
+}

--- a/internal/server/provider.go
+++ b/internal/server/provider.go
@@ -325,6 +325,7 @@ func (p *FormanceStackProvider) Resources(ctx context.Context) []func() resource
 		resources.NewPaymentsConnectors(),
 		resources.NewPaymentsPool(),
 		resources.NewReconciliationPolicy(),
+		resources.NewLedgerSchema(),
 	}
 	return collectionutils.Map(res, func(fn func() resource.Resource) func() resource.Resource {
 		return resources.NewResourceTracer(p.tracer, p.logger, fn())

--- a/internal/server/sdk/ledger.go
+++ b/internal/server/sdk/ledger.go
@@ -13,12 +13,23 @@ type LedgerSdkImpl interface {
 	GetLedger(ctx context.Context, request operations.V2GetLedgerRequest) (*operations.V2GetLedgerResponse, error)
 	DeleteLedger(ctx context.Context, name string) error
 	UpdateLedgerMetadata(ctx context.Context, request operations.V2UpdateLedgerMetadataRequest) (*operations.V2UpdateLedgerMetadataResponse, error)
+
+	GetSchema(ctx context.Context, request operations.V2GetSchemaRequest) (*operations.V2GetSchemaResponse, error)
+	InsertSchema(ctx context.Context, request operations.V2InsertSchemaRequest) (*operations.V2InsertSchemaResponse, error)
 }
 
 var _ LedgerSdkImpl = &defaultLedger{}
 
 type defaultLedger struct {
 	*formance.Ledger
+}
+
+func (s *defaultLedger) InsertSchema(ctx context.Context, request operations.V2InsertSchemaRequest) (*operations.V2InsertSchemaResponse, error) {
+	return s.V2.InsertSchema(ctx, request)
+}
+
+func (s *defaultLedger) GetSchema(ctx context.Context, request operations.V2GetSchemaRequest) (*operations.V2GetSchemaResponse, error) {
+	return s.V2.GetSchema(ctx, request)
 }
 
 func (s *defaultLedger) CreateLedger(ctx context.Context, request operations.V2CreateLedgerRequest) (*operations.V2CreateLedgerResponse, error) {

--- a/internal/server/sdk/ledger_generated.go
+++ b/internal/server/sdk/ledger_generated.go
@@ -157,6 +157,84 @@ func (c *MockLedgerSdkImplGetLedgerCall) DoAndReturn(f func(context.Context, ope
 	return c
 }
 
+// GetSchema mocks base method.
+func (m *MockLedgerSdkImpl) GetSchema(ctx context.Context, request operations.V2GetSchemaRequest) (*operations.V2GetSchemaResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchema", ctx, request)
+	ret0, _ := ret[0].(*operations.V2GetSchemaResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchema indicates an expected call of GetSchema.
+func (mr *MockLedgerSdkImplMockRecorder) GetSchema(ctx, request any) *MockLedgerSdkImplGetSchemaCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchema", reflect.TypeOf((*MockLedgerSdkImpl)(nil).GetSchema), ctx, request)
+	return &MockLedgerSdkImplGetSchemaCall{Call: call}
+}
+
+// MockLedgerSdkImplGetSchemaCall wrap *gomock.Call
+type MockLedgerSdkImplGetSchemaCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockLedgerSdkImplGetSchemaCall) Return(arg0 *operations.V2GetSchemaResponse, arg1 error) *MockLedgerSdkImplGetSchemaCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockLedgerSdkImplGetSchemaCall) Do(f func(context.Context, operations.V2GetSchemaRequest) (*operations.V2GetSchemaResponse, error)) *MockLedgerSdkImplGetSchemaCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockLedgerSdkImplGetSchemaCall) DoAndReturn(f func(context.Context, operations.V2GetSchemaRequest) (*operations.V2GetSchemaResponse, error)) *MockLedgerSdkImplGetSchemaCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// InsertSchema mocks base method.
+func (m *MockLedgerSdkImpl) InsertSchema(ctx context.Context, request operations.V2InsertSchemaRequest) (*operations.V2InsertSchemaResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertSchema", ctx, request)
+	ret0, _ := ret[0].(*operations.V2InsertSchemaResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InsertSchema indicates an expected call of InsertSchema.
+func (mr *MockLedgerSdkImplMockRecorder) InsertSchema(ctx, request any) *MockLedgerSdkImplInsertSchemaCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertSchema", reflect.TypeOf((*MockLedgerSdkImpl)(nil).InsertSchema), ctx, request)
+	return &MockLedgerSdkImplInsertSchemaCall{Call: call}
+}
+
+// MockLedgerSdkImplInsertSchemaCall wrap *gomock.Call
+type MockLedgerSdkImplInsertSchemaCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockLedgerSdkImplInsertSchemaCall) Return(arg0 *operations.V2InsertSchemaResponse, arg1 error) *MockLedgerSdkImplInsertSchemaCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockLedgerSdkImplInsertSchemaCall) Do(f func(context.Context, operations.V2InsertSchemaRequest) (*operations.V2InsertSchemaResponse, error)) *MockLedgerSdkImplInsertSchemaCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockLedgerSdkImplInsertSchemaCall) DoAndReturn(f func(context.Context, operations.V2InsertSchemaRequest) (*operations.V2InsertSchemaResponse, error)) *MockLedgerSdkImplInsertSchemaCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateLedgerMetadata mocks base method.
 func (m *MockLedgerSdkImpl) UpdateLedgerMetadata(ctx context.Context, request operations.V2UpdateLedgerMetadataRequest) (*operations.V2UpdateLedgerMetadataResponse, error) {
 	m.ctrl.T.Helper()

--- a/tests/integration/ledger_schema_test.go
+++ b/tests/integration/ledger_schema_test.go
@@ -1,0 +1,273 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	formance "github.com/formancehq/formance-sdk-go/v3"
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"go.opentelemetry.io/otel"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
+	cloudpkg "github.com/formancehq/terraform-provider-cloud/pkg"
+	"github.com/formancehq/terraform-provider-cloud/pkg/testprovider"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/terraform-provider-stack/internal/server"
+	"github.com/formancehq/terraform-provider-stack/internal/server/sdk"
+	"github.com/formancehq/terraform-provider-stack/pkg"
+)
+
+func TestLedgerSchema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cloudSdk := sdk.NewMockCloudSDK(ctrl)
+	tokenProvider, _ := testprovider.NewMockTokenProvider(ctrl)
+	stackTokenProvider := pkg.NewMockTokenProviderImpl(ctrl)
+	stacksdk := sdk.NewMockStackSdkImpl(ctrl)
+	ledgerSchema := sdk.NewMockLedgerSdkImpl(ctrl)
+	stackId := uuid.NewString()
+	organizationId := uuid.NewString()
+
+	stackProvider := server.NewStackProvider(
+		otel.GetTracerProvider(),
+
+		logging.Testing().WithField("test", t.Name()),
+		server.FormanceStackEndpoint("dummy-endpoint"),
+		server.FormanceStackClientId("organization_dummy-client-id"),
+		server.FormanceStackClientSecret("dummy-client-secret"),
+		transport,
+		func(creds cloudpkg.Creds, transport http.RoundTripper) sdk.CloudSDK {
+			return cloudSdk
+		},
+		tokenProvider,
+		func(transport http.RoundTripper, creds cloudpkg.Creds, tokenProvider cloudpkg.TokenProviderImpl, stack pkg.Stack) pkg.TokenProviderImpl {
+			return stackTokenProvider
+		},
+		func(...formance.SDKOption) (sdk.StackSdkImpl, error) {
+			return stacksdk, nil
+		},
+	)
+
+	// Module and sdk expectations
+	stacksdk.EXPECT().GetVersions(gomock.Any()).Return(&operations.GetVersionsResponse{
+		GetVersionsResponse: &shared.GetVersionsResponse{
+			Versions: []shared.Version{
+				{
+					Name:    "ledger",
+					Version: "develop",
+					Health:  true,
+				},
+			},
+		},
+	}, nil).AnyTimes()
+	stacksdk.EXPECT().Ledger().Return(ledgerSchema).AnyTimes()
+
+	schema := map[string]shared.V2ChartSegment{
+		"segment1": {
+			DotSelf: &shared.DotSelf{},
+		},
+		"segment2": {
+			DotMetadata: map[string]shared.V2ChartAccountMetadata{
+				"test": {
+					Default: pointer.For("test"),
+				},
+			},
+		},
+	}
+	ledgerSchema.EXPECT().InsertSchema(gomock.Any(), gomock.Cond(func(op operations.V2InsertSchemaRequest) bool {
+		return cmp.Diff(op, operations.V2InsertSchemaRequest{
+			Ledger:  "test-ledger",
+			Version: "v1.0.0",
+			V2SchemaData: shared.V2SchemaDataInput{
+				Chart: schema,
+			},
+		}) != ""
+	})).Return(&operations.V2InsertSchemaResponse{
+		StatusCode: http.StatusOK,
+	}, nil).Times(1)
+
+	ledgerSchema.EXPECT().GetSchema(gomock.Any(), operations.V2GetSchemaRequest{
+		Ledger:  "test-ledger",
+		Version: "v1.0.0",
+	}).Return(&operations.V2GetSchemaResponse{
+		StatusCode: http.StatusOK,
+		V2SchemaResponse: &shared.V2SchemaResponse{
+			Data: shared.V2Schema{
+				Version: "v1.0.0",
+				Data: shared.V2SchemaData{
+					Chart: schema,
+				},
+			},
+		},
+	}, nil).Times(2)
+
+	schemaUpdated := map[string]shared.V2ChartSegment{
+		"segment3": {
+			DotSelf: &shared.DotSelf{},
+		},
+		"segment2": {
+			DotMetadata: map[string]shared.V2ChartAccountMetadata{
+				"test": {
+					Default: pointer.For("test"),
+				},
+			},
+		},
+	}
+	ledgerSchema.EXPECT().InsertSchema(gomock.Any(), gomock.Cond(func(op operations.V2InsertSchemaRequest) bool {
+		return cmp.Diff(op, operations.V2InsertSchemaRequest{
+			Ledger:  "test-ledger",
+			Version: "v1.0.1",
+			V2SchemaData: shared.V2SchemaDataInput{
+				Chart: schemaUpdated,
+			},
+		}) != ""
+	})).Return(&operations.V2InsertSchemaResponse{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	ledgerSchema.EXPECT().GetSchema(gomock.Any(), operations.V2GetSchemaRequest{
+		Ledger:  "test-ledger",
+		Version: "v1.0.1",
+	}).Return(&operations.V2GetSchemaResponse{
+		StatusCode: http.StatusOK,
+		V2SchemaResponse: &shared.V2SchemaResponse{
+			Data: shared.V2Schema{
+				Version: "v1.0.1",
+				Data: shared.V2SchemaData{
+					Chart: schemaUpdated,
+				},
+			},
+		},
+	}, nil)
+	// testCases
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"stack": providerserver.NewProtocol6WithError(stackProvider()),
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_15_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "stack" {
+						stack_id = "` + stackId + `"
+						organization_id = "` + organizationId + `"
+						uri = "` + fmt.Sprintf("https://%s-%s.formance.cloud/api", organizationId, stackId) + `"
+					}
+
+					resource "stack_ledger_schema" "default" {
+						ledger = "test-ledger"
+						version = "v1.0.0"
+						schema = {
+							"segment1": {
+								".self": {}
+							},
+							"segment2": {
+								".metadata": {
+									"test": {
+										"default": "test"
+									}
+								}
+							}
+						}
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New(`schema`),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"segment1": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								".self": knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+							}),
+							"segment2": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								".metadata": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"test": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"default": knownvalue.StringExact("test"),
+									}),
+								}),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New("version"),
+						knownvalue.StringExact("v1.0.0"),
+					),
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New("ledger"),
+						knownvalue.StringExact("test-ledger"),
+					),
+				},
+			},
+			{
+				Config: `
+					provider "stack" {
+						stack_id = "` + stackId + `"
+						organization_id = "` + organizationId + `"
+						uri = "` + fmt.Sprintf("https://%s-%s.formance.cloud/api", organizationId, stackId) + `"
+					}
+
+					resource "stack_ledger_schema" "default" {
+						ledger = "test-ledger"
+						version = "v1.0.1"
+						schema = {
+							"segment3": {
+								".self": {}
+							},
+							"segment2": {
+								".metadata": {
+									"test": {
+										"default": "test"
+									}
+								}
+							}
+						}
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New(`schema`),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"segment3": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								".self": knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+							}),
+							"segment2": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								".metadata": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"test": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"default": knownvalue.StringExact("test"),
+									}),
+								}),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New("version"),
+						knownvalue.StringExact("v1.0.1"),
+					),
+					statecheck.ExpectKnownValue(
+						"stack_ledger_schema.default",
+						tfjsonpath.New("ledger"),
+						knownvalue.StringExact("test-ledger"),
+					),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Terraform resource to manage Formance Ledger schemas. It lets you insert and read versioned schemas via the Ledger v2 API, so you can provision and pin schema versions from Terraform.

- **New Features**
  - New resource: stack_ledger_schema with attributes ledger, version, schema (JSON).
  - Create inserts schema (InsertSchema); Read fetches it (GetSchema). Schema changes require replacement; Update/Delete are not implemented.
  - Provider registers the resource; Ledger SDK extended with InsertSchema and GetSchema; integration tests cover create and version bump.

- **Migration**
  - To modify a schema, bump the version to trigger replacement; delete is a no-op.

<sup>Written for commit 7ce927d8f803585b6205156c934ca2cc6dff3e5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

