### PR TITLE
fix(ci): use FORMANCE_CLOUD_API_ENDPOINT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
         env:
           PATH: ${PATH}:${PWD}/build
-          FORMANCE_CLOUD_API_ENDPOINT: https://app.staging.formance.cloud/api
+          FORMANCE_CLOUD_API_ENDPOINT: ${{ secrets.FORMANCE_CLOUD_API_ENDPOINT }}
           FORMANCE_CLOUD_CLIENT_ID: ${{ secrets.FORMANCE_CLOUD_CLIENT_ID }}
           FORMANCE_CLOUD_CLIENT_SECRET: ${{ secrets.FORMANCE_CLOUD_CLIENT_SECRET }}
           FORMANCE_CLOUD_REGION_NAME: ${{ secrets.FORMANCE_CLOUD_REGION_NAME }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update GitHub Actions to read FORMANCE_CLOUD_API_ENDPOINT from repository secrets instead of a hard-coded staging URL, enabling environment-specific endpoints and removing hard-coded config.

<sup>Written for commit 392a448666de6cf5412a07b697217b6585806c1f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

