### PR TITLE
feat: add e2e test for payments pool using query

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -98,9 +98,9 @@ delete-all-stack force="true":
   # Suppression de chaque stack
   for stack in $stacks; do
     if [[ "${force:-false}" == "true" ]]; then
-      fctl stacks delete "$stack" --force
+      fctl stacks delete "$stack" --force --confirm
     else
-      fctl stacks delete "$stack"
+      fctl stacks delete "$stack" --confirm
     fi
   done
 

--- a/internal/resources/payments_pool.go
+++ b/internal/resources/payments_pool.go
@@ -166,7 +166,7 @@ func (s *PaymentsPool) Create(ctx context.Context, req resource.CreateRequest, r
 
 	sdkPayments := s.store.Payments()
 	resp, err := sdkPayments.CreatePool(ctx, &shared.V3CreatePoolRequest{
-		Name: plan.Name.String(),
+		Name: plan.Name.ValueString(),
 		AccountIDs: collectionutils.Map(plan.AccountsIds.Elements(), func(account attr.Value) string {
 			return account.(types.String).ValueString()
 		}),

--- a/tests/e2e/payments_pool_query_test.go
+++ b/tests/e2e/payments_pool_query_test.go
@@ -1,0 +1,70 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestPaymentPoolQuery(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"cloud": providerserver.NewProtocol6WithError(CloudProvider()),
+			"stack": providerserver.NewProtocol6WithError(StackProvider()),
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_15_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						provider "stack" {
+							stack_id = cloud_stack.default.id
+							organization_id = data.cloud_current_organization.default.id
+							uri = cloud_stack.default.uri
+						}
+
+						data "cloud_current_organization" "default" {}
+
+						data "cloud_regions" "default" {
+							name = "` + RegionName + `"
+						}
+
+						resource "cloud_stack" "default" {
+							name = "test"
+							region_id = data.cloud_regions.default.id
+							version = "v3.2-rc.1"
+							force_destroy = true
+						}
+
+						resource "stack_payments_pool" "default" {
+							name = "default_pool"
+							query = {
+								"$match" = {
+									"id" = "1234567890"
+								}
+							}
+						}
+					`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("stack_payments_pool.default", tfjsonpath.New("query"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"$match": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id": knownvalue.StringExact("1234567890"),
+						}),
+					})),
+				},
+			},
+			{
+				RefreshState: true,
+			},
+		},
+	})
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an end-to-end test for stack_payments_pool using the query field. Fixed pool creation name handling and made stack deletion non-interactive.

- **New Features**
  - Added TestPaymentPoolQuery to assert the query map ($match.id) is kept in state.
  - Runs with cloud and stack providers and provisions a test stack (v3.2-rc.1).

- **Bug Fixes**
  - Use plan.Name.ValueString() when creating a payments pool.
  - Add --confirm to fctl stacks delete in Justfile to avoid interactive prompts.

<sup>Written for commit 67dd0d8568a8aa7355bc850cd7a0a93a615379cc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

