### PR TITLE
fix(e2e): remove hardcoded stack version from tests

### DIFF
--- a/tests/e2e/ledger_schema_test.go
+++ b/tests/e2e/ledger_schema_test.go
@@ -24,9 +24,9 @@ func TestLedgerSchemaChart(t *testing.T) {
 			tfversion.SkipBelow(tfversion.Version0_15_0),
 		},
 		Steps: []resource.TestStep{
-			newTestStepStack(),
+			newTestStepStackWithLatestVersion(),
 			{
-				Config: newStack(RegionName) +
+				Config: newStackWithLatestVersion(RegionName) +
 					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
@@ -79,9 +79,9 @@ func TestLedgerSchemaTransactions(t *testing.T) {
 			tfversion.SkipBelow(tfversion.Version0_15_0),
 		},
 		Steps: []resource.TestStep{
-			newTestStepStack(),
+			newTestStepStackWithLatestVersion(),
 			{
-				Config: newStack(RegionName) +
+				Config: newStackWithLatestVersion(RegionName) +
 					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
@@ -138,7 +138,7 @@ func TestLedgerSchemaTransactionsScriptError(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: newStack(RegionName) +
+				Config: newStackWithLatestVersion(RegionName) +
 					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id

--- a/tests/e2e/ledger_schema_test.go
+++ b/tests/e2e/ledger_schema_test.go
@@ -24,25 +24,14 @@ func TestLedgerSchemaChart(t *testing.T) {
 			tfversion.SkipBelow(tfversion.Version0_15_0),
 		},
 		Steps: []resource.TestStep{
+			newTestStepStack(),
 			{
-				Config: `
+				Config: newStack(RegionName) +
+					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
 							organization_id = data.cloud_current_organization.default.id
 							uri = cloud_stack.default.uri
-						}
-
-						data "cloud_current_organization" "default" {}
-
-						data "cloud_regions" "default" {
-							name = "` + RegionName + `"
-						}
-
-						resource "cloud_stack" "default" {
-							name = "test"
-							region_id = data.cloud_regions.default.id
-							version = "v3.2-rc.1"
-							force_destroy = true
 						}
 
 						resource "stack_ledger" "default" {
@@ -90,25 +79,14 @@ func TestLedgerSchemaTransactions(t *testing.T) {
 			tfversion.SkipBelow(tfversion.Version0_15_0),
 		},
 		Steps: []resource.TestStep{
+			newTestStepStack(),
 			{
-				Config: `
+				Config: newStack(RegionName) +
+					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
 							organization_id = data.cloud_current_organization.default.id
 							uri = cloud_stack.default.uri
-						}
-
-						data "cloud_current_organization" "default" {}
-
-						data "cloud_regions" "default" {
-							name = "` + RegionName + `"
-						}
-
-						resource "cloud_stack" "default" {
-							name = "test"
-							region_id = data.cloud_regions.default.id
-							version = "v3.2-rc.1"
-							force_destroy = true
 						}
 
 						resource "stack_ledger" "default" {
@@ -160,24 +138,12 @@ func TestLedgerSchemaTransactionsScriptError(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: newStack(RegionName) +
+					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
 							organization_id = data.cloud_current_organization.default.id
 							uri = cloud_stack.default.uri
-						}
-
-						data "cloud_current_organization" "default" {}
-
-						data "cloud_regions" "default" {
-							name = "` + RegionName + `"
-						}
-
-						resource "cloud_stack" "default" {
-							name = "test"
-							region_id = data.cloud_regions.default.id
-							version = "v3.2-rc.1"
-							force_destroy = true
 						}
 
 						resource "stack_ledger" "default" {

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -51,6 +51,18 @@ func newTestStepStack() resource.TestStep {
 	}
 }
 
+func newTestStepStackWithLatestVersion() resource.TestStep {
+	return resource.TestStep{
+		Config: newStackWithLatestVersion(RegionName),
+		ConfigStateChecks: []statecheck.StateCheck{
+			statecheck.ExpectKnownValue("cloud_stack.default", tfjsonpath.New("name"), knownvalue.StringExact("test")),
+			statecheck.ExpectKnownValue("cloud_stack.default", tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`.+`))),
+			statecheck.ExpectKnownValue("cloud_stack.default", tfjsonpath.New("force_destroy"), knownvalue.Bool(true)),
+			statecheck.ExpectKnownValue("cloud_stack.default", tfjsonpath.New("uri"), knownvalue.StringRegexp(regexp.MustCompile(`.+`))),
+		},
+	}
+}
+
 func TestMain(m *testing.M) {
 	endpoint := os.Getenv("FORMANCE_CLOUD_API_ENDPOINT")
 	clientID := os.Getenv("FORMANCE_CLOUD_CLIENT_ID")
@@ -159,6 +171,32 @@ func newStack(regionName string) string {
 		resource "cloud_stack" "default" {
 			name = "test"
 			region_id = data.cloud_regions.default.id
+
+			force_destroy = true
+		}
+	`
+}
+
+func newStackWithLatestVersion(regionName string) string {
+	return `
+		data "cloud_current_organization" "default" {}
+
+		data "cloud_regions" "default" {
+			name = "` + regionName + `"
+		}
+
+		data "cloud_region_versions" "default" {
+			id = data.cloud_regions.default.id
+		}
+
+		locals {
+			latest_version = data.cloud_region_versions.default.versions[length(data.cloud_region_versions.default.versions) - 1].name
+		}
+
+		resource "cloud_stack" "default" {
+			name = "test"
+			region_id = data.cloud_regions.default.id
+			version   = local.latest_version
 
 			force_destroy = true
 		}

--- a/tests/e2e/payments_connector_test.go
+++ b/tests/e2e/payments_connector_test.go
@@ -21,24 +21,12 @@ func TestPaymentConnector(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: newStack(RegionName) +
+					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
 							organization_id = data.cloud_current_organization.default.id
 							uri = cloud_stack.default.uri
-						}
-
-						data "cloud_current_organization" "default" {}
-
-						data "cloud_regions" "default" {
-							name = "` + RegionName + `"
-						}
-
-						resource "cloud_stack" "default" {
-							name = "test"
-							region_id = data.cloud_regions.default.id
-							version = "v3.2-rc.1"
-							force_destroy = true
 						}
 
 						resource "stack_payments_connectors" "default" {

--- a/tests/e2e/payments_pool_query_test.go
+++ b/tests/e2e/payments_pool_query_test.go
@@ -23,25 +23,14 @@ func TestPaymentPoolQuery(t *testing.T) {
 			tfversion.SkipBelow(tfversion.Version0_15_0),
 		},
 		Steps: []resource.TestStep{
+			newTestStepStack(),
 			{
-				Config: `
+				Config: newStack(RegionName) +
+					`
 						provider "stack" {
 							stack_id = cloud_stack.default.id
 							organization_id = data.cloud_current_organization.default.id
 							uri = cloud_stack.default.uri
-						}
-
-						data "cloud_current_organization" "default" {}
-
-						data "cloud_regions" "default" {
-							name = "` + RegionName + `"
-						}
-
-						resource "cloud_stack" "default" {
-							name = "test"
-							region_id = data.cloud_regions.default.id
-							version = "v3.2-rc.1"
-							force_destroy = true
 						}
 
 						resource "stack_payments_pool" "default" {


### PR DESCRIPTION
## Summary
- Remove hardcoded `version = "v3.2-rc.1"` from E2E tests that was causing "unknown version" errors in CI
- Refactor failing tests (`TestLedgerSchemaChart`, `TestLedgerSchemaTransactions`, `TestLedgerSchemaTransactionsScriptError`, `TestPaymentConnector`, `TestPaymentPoolQuery`) to use the `newStack()` helper and `newTestStepStack()` pattern, consistent with passing tests
- The API no longer recognizes `v3.2-rc.1` as a valid version; omitting version lets the API default to latest

## Test plan
- [ ] CI E2E tests should now pass (previously failing with "unknown version" on `cloud_stack` creation)
- [ ] Unit and integration tests remain unaffected